### PR TITLE
Move modifications from VerifiedWikiImporter to hooks

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -144,7 +144,9 @@
 			"handler": "handleHashWriterHooks"
 		},
 		"XmlDumpWriterOpenPage": "DataAccounting\\Hooks::onXmlDumpWriterOpenPage",
-		"XmlDumpWriterWriteRevision": "DataAccounting\\Hooks::onXmlDumpWriterWriteRevision"
+		"XmlDumpWriterWriteRevision": "DataAccounting\\Hooks::onXmlDumpWriterWriteRevision",
+		"ImportHandlePageXMLTag": "DataAccounting\\Hooks::onImportHandlePageXMLTag",
+		"ImportHandleRevisionXMLTag": "DataAccounting\\Hooks::onImportHandleRevisionXMLTag"
 	},
 	"HookHandlers": {
 		"handleHooks": {

--- a/extension.json
+++ b/extension.json
@@ -90,7 +90,8 @@
 		"VerifiedImport": {
 			"class": "DataAccounting\\SpecialVerifiedImport",
 			"services": [
-				"PermissionManager"
+				"PermissionManager",
+				"WikiImporterFactory"
 			]
 		},
 		"VerifiedExport": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -17,5 +17,6 @@
 	"apihelp-query+example-example-1": "Query 1",
 	"apihelp-query+example-example-2": "Query 2",
 	"contentaction-daact": "Sign 🔑",
-	"verifiedexport": "Verified Export"
+	"verifiedexport": "Verified Export",
+	"verifiedimport": "Verified Import"
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -16,13 +16,17 @@ use MediaWiki\Hook\SkinTemplateNavigationHook;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Revision\RevisionRecord;
+use MovePage;
 use MWException;
 use OutputPage;
 use Parser;
 use PPFrame;
+use RequestContext;
 use Skin;
 use SkinTemplate;
 use stdClass;
+use Title;
+use XMLReader;
 
 require_once 'ApiUtil.php';
 
@@ -199,6 +203,230 @@ class Hooks implements
 		);
 
 		$output .= $xmlBuilder->getPageMetadataByRevId( $revision->getId() );
+	}
+
+	public static function onImportHandlePageXMLTag( \WikiImporter $importer, array &$pageInfo ): bool {
+		// This method is for verified importer.
+		if ( $importer->getReader()->localName !== 'data_accounting_chain_height' ) {
+			return true;
+		}
+
+		$own_chain_height = getPageChainHeight( $pageInfo['title'] );
+
+		if ( $own_chain_height == 0 ) {
+			return false;
+		}
+
+		$imported_chain_height = $importer->nodeContents();
+		if ( $own_chain_height <= $imported_chain_height ) {
+			// Move and rename own page
+			// Rename the page that is about to be imported
+			$now = date( 'Y-m-d-H-i-s', time() );
+			$newTitle = $pageInfo['title'] . "_ChainHeight_{$own_chain_height}_$now";
+
+			$ot = Title::newFromText( $pageInfo['title'] );
+			$nt = Title::newFromText( $newTitle );
+			$mp = new MovePage( $ot, $nt );
+
+			$mp->moveIfAllowed(
+				RequestContext::getMain()->getUser(),
+				"Resolving naming collision because imported page has longer verified chain height.",
+				false
+			);
+		}
+
+		// This prevents continuing down the else-if statements in WikiImporter, which would reach `$tag != '#text'`
+		return false;
+	}
+
+	public static function onImportHandleRevisionXMLTag( \WikiImporter $importer, array $pageInfo, array $revisionInfo ): bool {
+		// This method is for verified importer.
+		if ( $importer->getReader()->localName !== 'verification' ) {
+			return true;
+		}
+
+		self::processVerification(
+			self::handleVerification( $importer ),
+			$pageInfo['_title']
+		);
+
+		return false;
+	}
+
+	private static function handleVerification( \WikiImporter $importer ): ?array {
+		// This method is for verified importer.
+		if ( $importer->getReader()->isEmptyElement ) {
+			return null;
+		}
+		$verificationInfo = [];
+		$normalFields = [
+			'domain_id',
+			'rev_id',
+			'verification_hash',
+			'time_stamp',
+			'signature',
+			'public_key',
+			'wallet_address' ];
+		while ( $importer->getReader()->read() ) {
+			if ( $importer->getReader()->nodeType == XMLReader::END_ELEMENT &&
+				$importer->getReader()->localName == 'verification' ) {
+				break;
+			}
+
+			$tag = $importer->getReader()->localName;
+
+			if ( in_array( $tag, $normalFields ) ) {
+				$verificationInfo[$tag] = $importer->nodeContents();
+			} elseif ( $tag == 'witness' ) {
+				$verificationInfo[$tag] = self::handleWitness( $importer );
+			}
+		}
+
+		return $verificationInfo;
+	}
+
+	private static function handleWitness( \WikiImporter $importer ): ?array {
+		// This method is for verified importer.
+		if ( $importer->getReader()->isEmptyElement ) {
+			return null;
+		}
+
+		$witnessInfo = [];
+		$normalFields = [
+			"domain_id",
+			"witness_event_verification_hash",
+			"witness_network",
+			"smart_contract_address",
+			"domain_manifest_verification_hash",
+			"merkle_root",
+			"structured_merkle_proof",
+			"witness_event_transaction_hash",
+			"sender_account_address"
+		];
+		while ( $importer->getReader()->read() ) {
+			if ( $importer->getReader()->nodeType == XMLReader::END_ELEMENT &&
+				$importer->getReader()->localName == 'witness' ) {
+				break;
+			}
+			$tag = $importer->getReader()->localName;
+			if ( in_array( $tag, $normalFields ) ) {
+				$witnessInfo[$tag] = $importer->nodeContents();
+			}
+		}
+		return $witnessInfo;
+	}
+
+	private static function processVerification( ?array $verificationInfo, string $title ) {
+		// This method is for verified importer.
+		$table = 'revision_verification';
+		$lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+		$dbw = $lb->getConnectionRef( DB_MASTER );
+
+		if ( $verificationInfo !== null ) {
+			$verificationInfo['page_title'] = $title;
+			$verificationInfo['source'] = 'imported';
+			unset( $verificationInfo["rev_id"] );
+
+			$res = $dbw->select(
+				$table,
+				[ 'revision_verification_id', 'rev_id', 'page_title', 'source' ],
+				[ 'page_title' => $title ],
+				__METHOD__,
+				[ 'ORDER BY' => 'revision_verification_id' ]
+			);
+			$last_row = [];
+			foreach ( $res as $row ) {
+				$last_row = $row;
+			}
+			if ( empty( $last_row ) ) {
+				// Do nothing if empty
+				return;
+			}
+
+			// Witness-specific
+			if ( isset( $verificationInfo['witness'] ) ) {
+				$witnessInfo = $verificationInfo['witness'];
+				$structured_merkle_proof = json_decode( $witnessInfo['structured_merkle_proof'], true );
+				unset( $witnessInfo['structured_merkle_proof'] );
+
+				//Check if witness_event_verification_hash is already present,
+				//if so skip import into witness_events
+
+				$rowWitness = $dbw->selectRow(
+					'witness_events',
+					[ 'witness_event_id', 'witness_event_verification_hash' ],
+					[ 'witness_event_verification_hash' => $witnessInfo['witness_event_verification_hash'] ]
+				);
+				if ( !$rowWitness ) {
+					$witnessInfo['source'] = 'imported';
+					$witnessInfo['domain_manifest_title'] = 'N/A';
+					$dbw->insert(
+						'witness_events',
+						$witnessInfo,
+					);
+					$local_witness_event_id = getMaxWitnessEventId( $dbw );
+					if ( $local_witness_event_id === null ) {
+						$local_witness_event_id = 1;
+					}
+				} else {
+					$local_witness_event_id = $rowWitness->witness_event_id;
+				}
+
+				// Patch revision_verification table to use the local version of
+				// witness_event_id instead of from the foreign version.
+				$dbw->update(
+					'revision_verification',
+					[ 'witness_event_id' => $local_witness_event_id ],
+					[ 'revision_verification_id' => $last_row->revision_verification_id ],
+				);
+
+				// Check if merkle tree proof is present, if so skip, if not
+				// import AND attribute to the correct witness_id
+				$revision_verification_hash = $verificationInfo['verification_hash'];
+
+				$rowProof = $dbw->selectRow(
+					'witness_merkle_tree',
+					[ 'witness_event_id' ],
+					[
+						'left_leaf=\'' . $revision_verification_hash . '\'' .
+						' OR right_leaf=\'' . $revision_verification_hash . '\''
+					]
+				);
+
+				if ( !$rowProof ) {
+					$latest_witness_event_id = $dbw->selectRow(
+						'witness_events',
+						[ 'max(witness_event_id) as witness_event_id' ],
+						''
+					)->witness_event_id;
+
+					foreach ( $structured_merkle_proof as $row ) {
+						$row["witness_event_id"] = $latest_witness_event_id;
+						$dbw->insert(
+							'witness_merkle_tree',
+							$row,
+						);
+					}
+				}
+
+				// This unset is important, otherwise the dbw->update for
+				// revision_verification accidentally includes witness.
+				unset( $verificationInfo["witness"] );
+			}
+			// End of witness-specific
+
+			$dbw->update(
+				$table,
+				$verificationInfo,
+				[ 'revision_verification_id' => $last_row->revision_verification_id ],
+				__METHOD__
+			);
+		} else {
+			$dbw->delete(
+				$table,
+				[ 'page_title' => $title ]
+			);
+		}
 	}
 
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -190,6 +190,7 @@ class Hooks implements
 	}
 
 	public static function onXmlDumpWriterOpenPage( \XmlDumpWriter $dumpWriter, string &$output, stdClass $page, \Title $title ): void {
+		// This method is for verified exporter.
 		$output .= \Xml::element(
 			'data_accounting_chain_height',
 			[],
@@ -198,6 +199,7 @@ class Hooks implements
 	}
 
 	public static function onXmlDumpWriterWriteRevision( \XmlDumpWriter $dumpWriter, string &$output, stdClass $page, string $text, RevisionRecord $revision ): void {
+		// This method is for verified exporter.
 		$xmlBuilder = new RevisionXmlBuilder(
 			MediaWikiServices::getInstance()->getDBLoadBalancer()
 		);

--- a/includes/SpecialVerifiedImport.php
+++ b/includes/SpecialVerifiedImport.php
@@ -164,7 +164,8 @@ class SpecialVerifiedImport extends SpecialPage {
 			$source = Status::newFatal( 'import-token-mismatch' );
 		} elseif ( $sourceName === 'upload' ) {
 			$isUpload = true;
-			$fullInterwikiPrefix = $request->getVal( 'usernamePrefix' );
+			# Data accounting modification: to "imported".
+			$fullInterwikiPrefix = "imported";
 			if ( $this->permManager->userHasRight( $user, 'importupload' ) ) {
 				$source = ImportStreamSource::newFromUpload( "xmlimport" );
 			} else {
@@ -336,12 +337,6 @@ class SpecialVerifiedImport extends SpecialPage {
 					'accept' => [ 'application/xml', 'text/xml' ],
 					'label-message' => 'import-upload-filename',
 					'required' => true,
-				],
-				'usernamePrefix' => [
-					'type' => 'text',
-					'name' => 'usernamePrefix',
-					'label-message' => 'import-upload-username-prefix',
-					// TODO: Is this field required?
 				],
 				'assignKnownUsers' => [
 					'type' => 'check',

--- a/includes/SpecialVerifiedImport.php
+++ b/includes/SpecialVerifiedImport.php
@@ -26,13 +26,16 @@
 
 namespace DataAccounting;
 
-use Html;
+use HTMLForm;
 use ImportReporter;
 use ImportStreamSource;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
 use PermissionsError;
 use SpecialPage;
+use Status;
+use WikiImporter;
+use WikiImporterFactory;
 use Xml;
 
 /**
@@ -49,33 +52,28 @@ use Xml;
  * @ingroup SpecialPage
  */
 class SpecialVerifiedImport extends SpecialPage {
-
-	private $sourceName = false;
-	private $interwiki = false;
-	private $subproject;
-	private $fullInterwikiPrefix;
-	private $mapping = 'default';
-	private $namespace;
-	private $rootpage = '';
-	private $frompage = '';
-	private $logcomment = false;
-	private $history = true;
-	private $includeTemplates = false;
-	private $pageLinkDepth;
-
 	/** @var array */
 	private $importSources;
-	private $assignKnownUsers;
-	private $usernamePrefix;
 
-	/**
-	 * @var PermissionManager
-	 */
+	/** @var PermissionManager */
 	private $permManager;
 
-	public function __construct() {
+	/** @var WikiImporterFactory */
+	private $wikiImporterFactory;
+
+	/**
+	 * @param PermissionManager $permManager
+	 * @param WikiImporterFactory $wikiImporterFactory
+	 */
+	public function __construct(
+		PermissionManager $permManager,
+		WikiImporterFactory $wikiImporterFactory
+	) {
+		// Data accounting modification
 		parent::__construct( 'VerifiedImport', 'import' );
-		$this->permManager = MediaWikiServices::getInstance()->getPermissionManager();
+
+		$this->permManager = $permManager;
+		$this->wikiImporterFactory = $wikiImporterFactory;
 	}
 
 	public function doesWrites() {
@@ -84,9 +82,7 @@ class SpecialVerifiedImport extends SpecialPage {
 
 	/**
 	 * Execute
-	 *
 	 * @param string|null $par
-	 *
 	 * @throws PermissionsError
 	 * @throws ReadOnlyError
 	 */
@@ -96,11 +92,8 @@ class SpecialVerifiedImport extends SpecialPage {
 		$this->setHeaders();
 		$this->outputHeader();
 
-		$this->getOutput()->setPageTitle( 'Verified Import' );
-
-		$this->namespace = $this->getConfig()->get( 'ImportTargetNamespace' );
-
 		$this->getOutput()->addModules( 'mediawiki.special.import' );
+		$this->getOutput()->addModuleStyles( 'mediawiki.special.import.styles.ooui' );
 
 		$this->importSources = $this->getConfig()->get( 'ImportSources' );
 		// Avoid phan error by checking the type
@@ -135,7 +128,7 @@ class SpecialVerifiedImport extends SpecialPage {
 		$this->checkReadOnly();
 
 		$request = $this->getRequest();
-		if ( $request->wasPosted() && $request->getVal( 'action' ) == 'submit' ) {
+		if ( $request->wasPosted() && $request->getRawVal( 'action' ) == 'submit' ) {
 			$this->doImport();
 		}
 		$this->showForm();
@@ -147,87 +140,91 @@ class SpecialVerifiedImport extends SpecialPage {
 	private function doImport() {
 		$isUpload = false;
 		$request = $this->getRequest();
-		$this->sourceName = $request->getVal( "source" );
-		$this->assignKnownUsers = true;
+		$sourceName = $request->getVal( 'source' );
+		$assignKnownUsers = $request->getCheck( 'assignKnownUsers' );
 
-		$this->logcomment = $request->getText( 'log-comment' );
-		$this->pageLinkDepth = $this->getConfig()->get( 'ExportMaxLinkDepth' ) == 0
+		$logcomment = $request->getText( 'log-comment' );
+		$pageLinkDepth = $this->getConfig()->get( 'ExportMaxLinkDepth' ) == 0
 			? 0
 			: $request->getIntOrNull( 'pagelink-depth' );
 
-		$this->mapping = $request->getVal( 'mapping' );
-		if ( $this->mapping === 'namespace' ) {
-			$this->namespace = $request->getIntOrNull( 'namespace' );
-		} elseif ( $this->mapping === 'subpage' ) {
-			$this->rootpage = $request->getText( 'rootpage' );
-		} else {
-			$this->mapping = 'default';
+		$rootpage = '';
+		$mapping = $request->getVal( 'mapping' );
+		$namespace = $this->getConfig()->get( 'ImportTargetNamespace' );
+		if ( $mapping === 'namespace' ) {
+			$namespace = $request->getIntOrNull( 'namespace' );
+		} elseif ( $mapping === 'subpage' ) {
+			$rootpage = $request->getText( 'rootpage' );
 		}
 
 		$user = $this->getUser();
-		if ( !$user->matchEditToken( $request->getVal( 'editToken' ) ) ) {
+
+		$fullInterwikiPrefix = null;
+		if ( !$user->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
 			$source = Status::newFatal( 'import-token-mismatch' );
-		} elseif ( $this->sourceName === 'upload' ) {
+		} elseif ( $sourceName === 'upload' ) {
 			$isUpload = true;
-			# Data accounting modification: to "imported".
-			$this->usernamePrefix = $this->fullInterwikiPrefix = "imported";
+			$fullInterwikiPrefix = $request->getVal( 'usernamePrefix' );
 			if ( $this->permManager->userHasRight( $user, 'importupload' ) ) {
 				$source = ImportStreamSource::newFromUpload( "xmlimport" );
 			} else {
 				throw new PermissionsError( 'importupload' );
 			}
-		} elseif ( $this->sourceName === 'interwiki' ) {
+		} elseif ( $sourceName === 'interwiki' ) {
 			if ( !$this->permManager->userHasRight( $user, 'import' ) ) {
 				throw new PermissionsError( 'import' );
 			}
-			$this->interwiki = $this->fullInterwikiPrefix = $request->getVal( 'interwiki' );
+			$interwiki = $fullInterwikiPrefix = $request->getVal( 'interwiki' );
 			// does this interwiki have subprojects?
-			$hasSubprojects = array_key_exists( $this->interwiki, $this->importSources );
-			if ( !$hasSubprojects && !in_array( $this->interwiki, $this->importSources ) ) {
+			$hasSubprojects = array_key_exists( $interwiki, $this->importSources );
+			if ( !$hasSubprojects && !in_array( $interwiki, $this->importSources ) ) {
 				$source = Status::newFatal( "import-invalid-interwiki" );
 			} else {
+				$subproject = null;
 				if ( $hasSubprojects ) {
-					$this->subproject = $request->getVal( 'subproject' );
-					$this->fullInterwikiPrefix .= ':' . $request->getVal( 'subproject' );
+					$subproject = $request->getVal( 'subproject' );
+					// Trim "project::" prefix added for JS
+					if ( strpos( $subproject, $interwiki . '::' ) === 0 ) {
+						$subproject = substr( $subproject, strlen( $interwiki . '::' ) );
+					}
+					$fullInterwikiPrefix .= ':' . $subproject;
 				}
 				if ( $hasSubprojects &&
-					!in_array( $this->subproject, $this->importSources[$this->interwiki] )
+					!in_array( $subproject, $this->importSources[$interwiki] )
 				) {
-					$source = Status::newFatal( "import-invalid-interwiki" );
+					$source = Status::newFatal( 'import-invalid-interwiki' );
 				} else {
-					$this->history = $request->getCheck( 'interwikiHistory' );
-					$this->frompage = $request->getText( "frompage" );
-					$this->includeTemplates = $request->getCheck( 'interwikiTemplates' );
+					$history = $request->getCheck( 'interwikiHistory' );
+					$frompage = $request->getText( 'frompage' );
+					$includeTemplates = $request->getCheck( 'interwikiTemplates' );
 					$source = ImportStreamSource::newFromInterwiki(
-						$this->fullInterwikiPrefix,
-						$this->frompage,
-						$this->history,
-						$this->includeTemplates,
-						$this->pageLinkDepth
-					);
+						$fullInterwikiPrefix,
+						$frompage,
+						$history,
+						$includeTemplates,
+						$pageLinkDepth );
 				}
 			}
 		} else {
 			$source = Status::newFatal( "importunknownsource" );
 		}
 
-		if ( (string)$this->fullInterwikiPrefix === '' ) {
+		if ( (string)$fullInterwikiPrefix === '' ) {
 			$source->fatal( 'importnoprefix' );
 		}
 
 		$out = $this->getOutput();
 		if ( !$source->isGood() ) {
-			$out->wrapWikiTextAsInterface(
-				'error',
+			$out->wrapWikiTextAsInterface( 'error',
 				$this->msg( 'importfailed', $source->getWikiText( false, false, $this->getLanguage() ) )
 					->plain()
 			);
 		} else {
-			$importer = new VerifiedWikiImporter( $source->value, $this->getConfig() );
-			if ( $this->namespace !== null ) {
-				$importer->setTargetNamespace( $this->namespace );
-			} elseif ( $this->rootpage !== null ) {
-				$statusRootPage = $importer->setTargetRootPage( $this->rootpage );
+			$importer = $this->wikiImporterFactory->getWikiImporter( $source->value );
+			if ( $namespace !== null ) {
+				$importer->setTargetNamespace( $namespace );
+			} elseif ( $rootpage !== null ) {
+				$statusRootPage = $importer->setTargetRootPage( $rootpage );
 				if ( !$statusRootPage->isGood() ) {
 					$out->wrapWikiMsg(
 						"<div class=\"error\">\n$1\n</div>",
@@ -241,15 +238,15 @@ class SpecialVerifiedImport extends SpecialPage {
 					return;
 				}
 			}
-			$importer->setUsernamePrefix( $this->fullInterwikiPrefix, $this->assignKnownUsers );
+			$importer->setUsernamePrefix( $fullInterwikiPrefix, $assignKnownUsers );
 
 			$out->addWikiMsg( "importstart" );
 
 			$reporter = new ImportReporter(
 				$importer,
 				$isUpload,
-				$this->fullInterwikiPrefix,
-				$this->logcomment
+				$fullInterwikiPrefix,
+				$logcomment
 			);
 			$reporter->setContext( $this->getContext() );
 			$exception = false;
@@ -257,8 +254,7 @@ class SpecialVerifiedImport extends SpecialPage {
 			$reporter->open();
 			try {
 				$importer->doImport();
-			}
-			catch ( Exception $e ) {
+			} catch ( Exception $e ) {
 				$exception = $e;
 			}
 			$result = $reporter->close();
@@ -284,77 +280,37 @@ class SpecialVerifiedImport extends SpecialPage {
 	}
 
 	private function getMappingFormPart( $sourceName ) {
-		$isSameSourceAsBefore = ( $this->sourceName === $sourceName );
 		$defaultNamespace = $this->getConfig()->get( 'ImportTargetNamespace' );
-		return "<tr>
-					<td>
-					</td>
-					<td class='mw-input'>" .
-			Xml::radioLabel(
-				$this->msg( 'import-mapping-default' )->text(),
-				'mapping',
-				'default',
-				// mw-import-mapping-interwiki-default, mw-import-mapping-upload-default
-				"mw-import-mapping-$sourceName-default",
-				( $isSameSourceAsBefore ?
-					( $this->mapping === 'default' ) :
-					$defaultNamespace === null )
-			) .
-			"</td>
-				</tr>
-				<tr>
-					<td>
-					</td>
-					<td class='mw-input'>" .
-			Xml::radioLabel(
-				$this->msg( 'import-mapping-namespace' )->text(),
-				'mapping',
-				'namespace',
-				// mw-import-mapping-interwiki-namespace, mw-import-mapping-upload-namespace
-				"mw-import-mapping-$sourceName-namespace",
-				( $isSameSourceAsBefore ?
-					( $this->mapping === 'namespace' ) :
-					$defaultNamespace !== null )
-			) . ' ' .
-			Html::namespaceSelector(
-				[
-					'selected' => ( $isSameSourceAsBefore ?
-						$this->namespace :
-						( $defaultNamespace || '' ) ),
-					'in-user-lang' => true,
-				], [
-					'name' => "namespace",
-					// mw-import-namespace-interwiki, mw-import-namespace-upload
-					'id' => "mw-import-namespace-$sourceName",
-					'class' => 'namespaceselector',
-				]
-			) .
-			"</td>
-				</tr>
-				<tr>
-					<td>
-					</td>
-					<td class='mw-input'>" .
-			Xml::radioLabel(
-				$this->msg( 'import-mapping-subpage' )->text(),
-				'mapping',
-				'subpage',
-				// mw-import-mapping-interwiki-subpage, mw-import-mapping-upload-subpage
-				"mw-import-mapping-$sourceName-subpage",
-				( $isSameSourceAsBefore ? ( $this->mapping === 'subpage' ) : '' )
-			) . ' ' .
-			Xml::input( 'rootpage', 50,
-				( $isSameSourceAsBefore ? $this->rootpage : '' ),
-				[
-					// Should be "mw-import-rootpage-...", but we keep this inaccurate
-					// ID for legacy reasons
-					// mw-interwiki-rootpage-interwiki, mw-interwiki-rootpage-upload
-					'id' => "mw-interwiki-rootpage-$sourceName",
-					'type' => 'text'
-				]
-			) . ' ' .
-			"</td>
-				</tr>";
+		return [
+			'mapping' => [
+				'type' => 'radio',
+				'name' => 'mapping',
+				// mw-import-mapping-interwiki, mw-import-mapping-upload
+				'id' => "mw-import-mapping-$sourceName",
+				'options-messages' => [
+					'import-mapping-default' => 'default',
+					'import-mapping-namespace' => 'namespace',
+					'import-mapping-subpage' => 'subpage'
+				],
+				'default' => $defaultNamespace !== null ? 'namespace' : 'default'
+			],
+			'namespace' => [
+				'type' => 'namespaceselect',
+				'name' => 'namespace',
+				// mw-import-namespace-interwiki, mw-import-namespace-upload
+				'id' => "mw-import-namespace-$sourceName",
+				'default' => $defaultNamespace ?: '',
+				'all' => null
+			],
+			'rootpage' => [
+				'type' => 'text',
+				'name' => 'rootpage',
+				// Should be "mw-import-rootpage-...", but we keep this inaccurate
+				// ID for legacy reasons
+				// mw-interwiki-rootpage-interwiki, mw-interwiki-rootpage-upload
+				'id' => "mw-interwiki-rootpage-$sourceName",
+			],
+		];
 	}
 
 	private function showForm() {
@@ -363,98 +319,64 @@ class SpecialVerifiedImport extends SpecialPage {
 		$out = $this->getOutput();
 		$this->addHelpLink( 'https://meta.wikimedia.org/wiki/Special:MyLanguage/Help:Import', true );
 
+		$interwikiFormDescriptor = [];
+		$uploadFormDescriptor = [];
+
 		if ( $this->permManager->userHasRight( $user, 'importupload' ) ) {
 			$mappingSelection = $this->getMappingFormPart( 'upload' );
-			$out->addHTML(
-				Xml::fieldset( $this->msg( 'import-upload' )->text() ) .
-				Xml::openElement(
-					'form',
-					[
-						'enctype' => 'multipart/form-data',
-						'method' => 'post',
-						'action' => $action,
-						'id' => 'mw-import-upload-form'
-					]
-				) .
-				$this->msg( 'importtext' )->parseAsBlock() .
-				Html::hidden( 'action', 'submit' ) .
-				Html::hidden( 'source', 'upload' ) .
-				Xml::openElement( 'table', [ 'id' => 'mw-import-table-upload' ] ) .
-				"<tr>
-					<td class='mw-label'>" .
-				Xml::label( $this->msg( 'import-upload-filename' )->text(), 'xmlimport' ) .
-				"</td>
-					<td class='mw-input'>" .
-				Html::input( 'xmlimport', '', 'file', [ 'id' => 'xmlimport' ] ) . ' ' .
-				"</td>
-				</tr>
-				<tr>
-					<td class='mw-label'>" .
-				Xml::label( $this->msg( 'import-comment' )->text(), 'mw-import-comment' ) .
-				"</td>
-					<td class='mw-input'>" .
-				Xml::input( 'log-comment', 50,
-					( $this->sourceName === 'upload' ? $this->logcomment : '' ),
-					[ 'id' => 'mw-import-comment', 'type' => 'text' ] ) . ' ' .
-				"</td>
-				</tr>
-				$mappingSelection
-				<tr>
-					<td></td>
-					<td class='mw-submit'>" .
-				Xml::submitButton( $this->msg( 'uploadbtn' )->text() ) .
-				"</td>
-				</tr>" .
-				Xml::closeElement( 'table' ) .
-				Html::hidden( 'editToken', $user->getEditToken() ) .
-				Xml::closeElement( 'form' ) .
-				Xml::closeElement( 'fieldset' )
-			);
+			$uploadFormDescriptor += [
+				'intro' => [
+					'type' => 'info',
+					'raw' => true,
+					'default' => $this->msg( 'importtext' )->parseAsBlock()
+				],
+				'xmlimport' => [
+					'type' => 'file',
+					'name' => 'xmlimport',
+					'accept' => [ 'application/xml', 'text/xml' ],
+					'label-message' => 'import-upload-filename',
+					'required' => true,
+				],
+				'usernamePrefix' => [
+					'type' => 'text',
+					'name' => 'usernamePrefix',
+					'label-message' => 'import-upload-username-prefix',
+					// TODO: Is this field required?
+				],
+				'assignKnownUsers' => [
+					'type' => 'check',
+					'name' => 'assignKnownUsers',
+					'label-message' => 'import-assign-known-users'
+				],
+				'log-comment' => [
+					'type' => 'text',
+					'name' => 'log-comment',
+					'label-message' => 'import-comment'
+				],
+				'source' => [
+					'type' => 'hidden',
+					'name' => 'source',
+					'default' => 'upload',
+					'id' => '',
+				],
+			];
+
+			$uploadFormDescriptor += $mappingSelection;
+
+			$htmlForm = HTMLForm::factory( 'ooui', $uploadFormDescriptor, $this->getContext() );
+			$htmlForm->setAction( $action );
+			$htmlForm->setId( 'mw-import-upload-form' );
+			$htmlForm->setWrapperLegendMsg( 'import-upload' );
+			$htmlForm->setSubmitTextMsg( 'uploadbtn' );
+			$htmlForm->prepareForm()->displayForm( false );
+
 		} elseif ( empty( $this->importSources ) ) {
 			$out->addWikiMsg( 'importnosources' );
 		}
 
 		if ( $this->permManager->userHasRight( $user, 'import' ) && !empty( $this->importSources ) ) {
-			# Show input field for import depth only if $wgExportMaxLinkDepth > 0
-			$importDepth = '';
-			if ( $this->getConfig()->get( 'ExportMaxLinkDepth' ) > 0 ) {
-				$importDepth = "<tr>
-							<td class='mw-label'>" .
-					$this->msg( 'export-pagelinks' )->parse() .
-					"</td>
-							<td class='mw-input'>" .
-					Xml::input( 'pagelink-depth', 3, 0 ) .
-					"</td>
-				</tr>";
-			}
-			$mappingSelection = $this->getMappingFormPart( 'interwiki' );
 
-			$out->addHTML(
-				Xml::fieldset( $this->msg( 'importinterwiki' )->text() ) .
-				Xml::openElement(
-					'form',
-					[
-						'method' => 'post',
-						'action' => $action,
-						'id' => 'mw-import-interwiki-form'
-					]
-				) .
-				$this->msg( 'import-interwiki-text' )->parseAsBlock() .
-				Html::hidden( 'action', 'submit' ) .
-				Html::hidden( 'source', 'interwiki' ) .
-				Html::hidden( 'editToken', $user->getEditToken() ) .
-				Xml::openElement( 'table', [ 'id' => 'mw-import-table-interwiki' ] ) .
-				"<tr>
-					<td class='mw-label'>" .
-				Xml::label( $this->msg( 'import-interwiki-sourcewiki' )->text(), 'interwiki' ) .
-				"</td>
-					<td class='mw-input'>" .
-				Xml::openElement(
-					'select',
-					[ 'name' => 'interwiki', 'id' => 'interwiki' ]
-				)
-			);
-
+			$projects = [];
 			$needSubprojectField = false;
 			foreach ( $this->importSources as $key => $value ) {
 				if ( is_int( $key ) ) {
@@ -463,108 +385,99 @@ class SpecialVerifiedImport extends SpecialPage {
 					$needSubprojectField = true;
 				}
 
-				$attribs = [
-					'value' => $key,
-				];
-				if ( is_array( $value ) ) {
-					$attribs['data-subprojects'] = implode( ' ', $value );
-				}
-				if ( $this->interwiki === $key ) {
-					$attribs['selected'] = 'selected';
-				}
-				$out->addHTML( Html::element( 'option', $attribs, $key ) );
+				$projects[ $key ] = $key;
 			}
 
-			$out->addHTML(
-				Xml::closeElement( 'select' )
-			);
+			$interwikiFormDescriptor += [
+				'intro' => [
+					'type' => 'info',
+					'raw' => true,
+					'default' => $this->msg( 'import-interwiki-text' )->parseAsBlock()
+				],
+				'interwiki' => [
+					'type' => 'select',
+					'name' => 'interwiki',
+					'label-message' => 'import-interwiki-sourcewiki',
+					'options' => $projects
+				],
+			];
 
 			if ( $needSubprojectField ) {
-				$out->addHTML(
-					Xml::openElement(
-						'select',
-						[ 'name' => 'subproject', 'id' => 'subproject' ]
-					)
-				);
-
-				$subprojectsToAdd = [];
+				$subprojects = [];
 				foreach ( $this->importSources as $key => $value ) {
 					if ( is_array( $value ) ) {
-						$subprojectsToAdd = array_merge( $subprojectsToAdd, $value );
+						foreach ( $value as $subproject ) {
+							$subprojects[ $subproject ] = $key . '::' . $subproject;
+						}
 					}
 				}
-				$subprojectsToAdd = array_unique( $subprojectsToAdd );
-				sort( $subprojectsToAdd );
-				foreach ( $subprojectsToAdd as $subproject ) {
-					$out->addHTML( Xml::option( $subproject, $subproject, $this->subproject === $subproject ) );
-				}
 
-				$out->addHTML(
-					Xml::closeElement( 'select' )
-				);
+				$interwikiFormDescriptor += [
+					'subproject' => [
+						'type' => 'select',
+						'name' => 'subproject',
+						'options' => $subprojects
+					]
+				];
 			}
 
-			$out->addHTML(
-				"</td>
-				</tr>
-				<tr>
-					<td class='mw-label'>" .
-				Xml::label( $this->msg( 'import-interwiki-sourcepage' )->text(), 'frompage' ) .
-				"</td>
-					<td class='mw-input'>" .
-				Xml::input( 'frompage', 50, $this->frompage, [ 'id' => 'frompage' ] ) .
-				"</td>
-				</tr>
-				<tr>
-					<td>
-					</td>
-					<td class='mw-input'>" .
-				Xml::checkLabel(
-					$this->msg( 'import-interwiki-history' )->text(),
-					'interwikiHistory',
-					'interwikiHistory',
-					$this->history
-				) .
-				"</td>
-				</tr>
-				<tr>
-					<td>
-					</td>
-					<td class='mw-input'>" .
-				Xml::checkLabel(
-					$this->msg( 'import-interwiki-templates' )->text(),
-					'interwikiTemplates',
-					'interwikiTemplates',
-					$this->includeTemplates
-				) .
-				"</td>
-				</tr>
-				$importDepth
-				<tr>
-					<td class='mw-label'>" .
-				Xml::label( $this->msg( 'import-comment' )->text(), 'mw-interwiki-comment' ) .
-				"</td>
-					<td class='mw-input'>" .
-				Xml::input( 'log-comment', 50,
-					( $this->sourceName === 'interwiki' ? $this->logcomment : '' ),
-					[ 'id' => 'mw-interwiki-comment', 'type' => 'text' ] ) . ' ' .
-				"</td>
-				</tr>
-				$mappingSelection
-				<tr>
-					<td>
-					</td>
-					<td class='mw-submit'>" .
-				Xml::submitButton(
-					$this->msg( 'import-interwiki-submit' )->text(),
-					Linker::tooltipAndAccesskeyAttribs( 'import' )
-				) .
-				"</td>
-				</tr>" .
-				Xml::closeElement( 'table' ) .
-				Xml::closeElement( 'form' ) .
-				Xml::closeElement( 'fieldset' )
-			);
+			$interwikiFormDescriptor += [
+				'frompage' => [
+					'type' => 'text',
+					'name' => 'frompage',
+					'label-message' => 'import-interwiki-sourcepage'
+				],
+				'interwikiHistory' => [
+					'type' => 'check',
+					'name' => 'interwikiHistory',
+					'label-message' => 'import-interwiki-history'
+				],
+				'interwikiTemplates' => [
+					'type' => 'check',
+					'name' => 'interwikiTemplates',
+					'label-message' => 'import-interwiki-templates'
+				],
+				'assignKnownUsers' => [
+					'type' => 'check',
+					'name' => 'assignKnownUsers',
+					'label-message' => 'import-assign-known-users'
+				],
+			];
+
+			if ( $this->getConfig()->get( 'ExportMaxLinkDepth' ) > 0 ) {
+				$interwikiFormDescriptor += [
+					'pagelink-depth' => [
+						'type' => 'int',
+						'name' => 'pagelink-depth',
+						'label-message' => 'export-pagelinks',
+						'default' => 0
+					]
+				];
+			}
+
+			$interwikiFormDescriptor += [
+				'log-comment' => [
+					'type' => 'text',
+					'name' => 'log-comment',
+					'label-message' => 'import-comment'
+				],
+				'source' => [
+					'type' => 'hidden',
+					'name' => 'source',
+					'default' => 'interwiki',
+					'id' => '',
+				],
+			];
+			$mappingSelection = $this->getMappingFormPart( 'interwiki' );
+
+			$interwikiFormDescriptor += $mappingSelection;
+
+			$htmlForm = HTMLForm::factory( 'ooui', $interwikiFormDescriptor, $this->getContext() );
+			$htmlForm->setAction( $action );
+			$htmlForm->setId( 'mw-import-interwiki-form' );
+			$htmlForm->setWrapperLegendMsg( 'importinterwiki' );
+			$htmlForm->setSubmitTextMsg( 'import-interwiki-submit' );
+			$htmlForm->prepareForm()->displayForm( false );
 		}
 	}
 

--- a/includes/SpecialVerifiedImport.php
+++ b/includes/SpecialVerifiedImport.php
@@ -141,7 +141,8 @@ class SpecialVerifiedImport extends SpecialPage {
 		$isUpload = false;
 		$request = $this->getRequest();
 		$sourceName = $request->getVal( 'source' );
-		$assignKnownUsers = $request->getCheck( 'assignKnownUsers' );
+		# Data accounting modification: hardcoded to true.
+		$assignKnownUsers = true;
 
 		$logcomment = $request->getText( 'log-comment' );
 		$pageLinkDepth = $this->getConfig()->get( 'ExportMaxLinkDepth' ) == 0
@@ -337,11 +338,6 @@ class SpecialVerifiedImport extends SpecialPage {
 					'accept' => [ 'application/xml', 'text/xml' ],
 					'label-message' => 'import-upload-filename',
 					'required' => true,
-				],
-				'assignKnownUsers' => [
-					'type' => 'check',
-					'name' => 'assignKnownUsers',
-					'label-message' => 'import-assign-known-users'
 				],
 				'log-comment' => [
 					'type' => 'text',


### PR DESCRIPTION
This allows removing VerifiedWikiImporter, and just use the normal WikiImporter.

WikiImporter not removed in this commit yet. Changes also not tested in any way.

With this commit, both Special:Import and Special:VerifiedImport will cause the
code in the hooks to be executed. This might be undesired. I am currently not
sure what the implications are, perhaps standard import is broken now.

Next steps:

* Test
* Remove VerifiedWikiImporter if we indeed moved all modifications
* Update SpecialVerifiedImport to use WikiImporter
* See if we can reduce duplication in SpecialVerifiedImport
* Move the code out of Hooks class into dedicated services, esp
  the 200 LOC in onImportHandleRevisionXMLTag